### PR TITLE
优化不能全屏、新闻页面部分布局高度问题

### DIFF
--- a/app/src/main/java/com/will/weiyuekotlin/MainActivity.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/MainActivity.kt
@@ -54,6 +54,7 @@ class MainActivity : BaseActivity<BaseContract.BasePresenter>() {
 
         mBootomBar.setOnTabSelectedListener(object : BottomBar.OnTabSelectedListener {
             override fun onTabSelected(position: Int, prePosition: Int) {
+                JCVideoPlayer.releaseAllVideos()
                 supportDelegate.showHideFragment(mFragments[position], mFragments[prePosition])
             }
 

--- a/app/src/main/java/com/will/weiyuekotlin/MyApp.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/MyApp.kt
@@ -1,6 +1,6 @@
 package com.will.weiyuekotlin
 
-import cn.bingoogolapple.swipebacklayout.BGASwipeBackManager
+import cn.bingoogolapple.swipebacklayout.BGASwipeBackHelper
 import com.will.weiyuekotlin.component.ApplicationComponent
 import com.will.weiyuekotlin.component.DaggerApplicationComponent
 import com.will.weiyuekotlin.module.ApplicationModule
@@ -32,6 +32,6 @@ class MyApp : LitePalApplication() {
         //初始化数据库
         LitePal.initialize(this)
         //初始化侧滑返回组件
-        BGASwipeBackManager.getInstance().init(this)
+        BGASwipeBackHelper.init(this, null)
     }
 }

--- a/app/src/main/java/com/will/weiyuekotlin/ui/adapter/VideoDetailAdapter.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/ui/adapter/VideoDetailAdapter.kt
@@ -22,23 +22,40 @@ import fm.jiecao.jcvideoplayer_lib.JCVideoPlayerStandard
 class VideoDetailAdapter(private var context: Context, @LayoutRes layoutResId: Int, data: List<VideoDetailBean.ItemBean>?)
     : BaseQuickAdapter<VideoDetailBean.ItemBean, BaseViewHolder>(layoutResId, data) {
 
+    var currentPlayIndex = -1
+    var lastPlayIndex = -1
     override fun convert(viewHolder: BaseViewHolder, itemBean: VideoDetailBean.ItemBean) {
         // viewHolder.setText(R.id.tv_title, itemBean.getTitle());
         val jcVideoPlayerStandard = viewHolder.getView<JCVideoPlayerStandard>(R.id.videoplayer)
         jcVideoPlayerStandard.setUp(itemBean.video_url, JCVideoPlayerStandard.SCREEN_LAYOUT_NORMAL, itemBean.title)
-        JCVideoPlayer.setJcUserAction({ type, _, _, _ ->
+        JCVideoPlayer.setJcUserAction { type, _, _, _ ->
             when (type) {
                 JCUserAction.ON_CLICK_START_ICON -> {
+                    currentPlayIndex = mData.indexOf(itemBean)
                     viewHolder.getView<View>(R.id.tv_videoduration).visibility = View.GONE
                 }
             }
-        })
+        }
         ImageLoaderUtil.LoadImage(context, itemBean.image, jcVideoPlayerStandard.thumbImageView)
         viewHolder.setText(R.id.tv_videoduration, conversionTime(itemBean.duration))
         itemBean.playTime?.let {
             viewHolder.setText(R.id.tv_playtime, conversionPlayTime(Integer.valueOf(it)!!))
         }
 
+        if (lastPlayIndex != currentPlayIndex && currentPlayIndex == mData.indexOf(itemBean)) {
+            jcVideoPlayerStandard.startVideo()
+        }
+
+    }
+
+    fun play(currentPlayIndex: Int) {
+        if (this.currentPlayIndex == currentPlayIndex) {
+            return
+        }
+        JCVideoPlayer.releaseAllVideos()
+        lastPlayIndex = this.currentPlayIndex
+        this.currentPlayIndex = currentPlayIndex
+        notifyDataSetChanged()
     }
 
 }

--- a/app/src/main/java/com/will/weiyuekotlin/ui/jandan/JanDanFragment.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/ui/jandan/JanDanFragment.kt
@@ -56,7 +56,7 @@ class JanDanFragment : BaseFragment<BasePresenter<BaseContract.BaseView>>() {
         strings.add("段子")
         mJanDanPagerAdapter = JanDanPagerAdapter(childFragmentManager, strings)
         viewpager.adapter = mJanDanPagerAdapter
-        viewpager.offscreenPageLimit = 1
+        viewpager.offscreenPageLimit = 5
         viewpager.setCurrentItem(0, false)
         tablayout.setupWithViewPager(viewpager, true)
     }

--- a/app/src/main/java/com/will/weiyuekotlin/ui/video/DetailFragment.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/ui/video/DetailFragment.kt
@@ -5,6 +5,7 @@ import `in`.srain.cube.views.ptr.PtrFrameLayout
 import `in`.srain.cube.views.ptr.PtrHandler
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.view.View
 import com.chad.library.adapter.base.BaseQuickAdapter
 import com.will.weiyuekotlin.R
@@ -18,6 +19,7 @@ import com.will.weiyuekotlin.ui.video.contract.VideoContract
 import com.will.weiyuekotlin.ui.video.presenter.VideoPresenter
 import com.will.weiyuekotlin.widget.CustomLoadMoreView
 import com.will.weiyuekotlin.widget.SimpleMultiStateView
+import fm.jiecao.jcvideoplayer_lib.JCVideoPlayer
 import kotlinx.android.synthetic.main.fragment_detail.*
 
 
@@ -62,6 +64,9 @@ class DetailFragment : BaseFragment<VideoPresenter>(), VideoContract.View {
             }
 
             override fun onRefreshBegin(frame: PtrFrameLayout) {
+                detailAdapter.lastPlayIndex=-1
+                detailAdapter.currentPlayIndex=-1
+                JCVideoPlayer.releaseAllVideos()
                 pageNum = 1
                 mPresenter?.getVideoDetails(pageNum, "list", typeId!!)
             }
@@ -74,6 +79,31 @@ class DetailFragment : BaseFragment<VideoPresenter>(), VideoContract.View {
         detailAdapter.setLoadMoreView(CustomLoadMoreView())
         detailAdapter.openLoadAnimation(BaseQuickAdapter.ALPHAIN)
         detailAdapter.setOnLoadMoreListener({ mPresenter?.getVideoDetails(pageNum, "list", typeId!!) }, mRecyclerView)
+
+        //添加滑动自动播放
+        mRecyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+
+            override fun onScrollStateChanged(recyclerView: RecyclerView?, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                when (newState) {
+                    RecyclerView.SCROLL_STATE_IDLE -> {
+                        val layoutManager = mRecyclerView.layoutManager as LinearLayoutManager
+                        //获取第一个可见view的位置
+                        val currentVisiableItemPosition: Int = layoutManager.findFirstVisibleItemPosition()
+                        autoPlayNext(currentVisiableItemPosition)
+
+                    }
+                }
+            }
+
+        })
+    }
+
+    /**
+     * 播放下一个
+     */
+    private fun autoPlayNext(currentVisiableItemPosition: Int) {
+        detailAdapter.play(currentVisiableItemPosition + 1)
     }
 
     override fun initData() {

--- a/app/src/main/java/com/will/weiyuekotlin/ui/video/VideoFragment.kt
+++ b/app/src/main/java/com/will/weiyuekotlin/ui/video/VideoFragment.kt
@@ -1,6 +1,7 @@
 package com.will.weiyuekotlin.ui.video
 
 import android.os.Bundle
+import android.support.v4.view.ViewPager
 import android.view.View
 import com.will.weiyuekotlin.R
 import com.will.weiyuekotlin.bean.VideoChannelBean
@@ -12,6 +13,7 @@ import com.will.weiyuekotlin.ui.base.BaseFragment
 import com.will.weiyuekotlin.ui.video.contract.VideoContract
 import com.will.weiyuekotlin.ui.video.presenter.VideoPresenter
 import com.will.weiyuekotlin.widget.SimpleMultiStateView
+import fm.jiecao.jcvideoplayer_lib.JCVideoPlayer
 import kotlinx.android.synthetic.main.fragment_video.*
 
 
@@ -60,9 +62,20 @@ class VideoFragment : BaseFragment<VideoPresenter>(), VideoContract.View {
     override fun loadVideoChannel(channelBean: List<VideoChannelBean>?) {
         mVideoPagerAdapter = VideoPagerAdapter(childFragmentManager, channelBean?.get(0))
         viewPager.adapter = mVideoPagerAdapter
-        viewPager.offscreenPageLimit = 1
+        viewPager.offscreenPageLimit = 5
         viewPager.setCurrentItem(0, false)
         tabLayout.setupWithViewPager(viewPager, true)
+        viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener{
+            override fun onPageScrollStateChanged(state: Int) {
+            }
+
+            override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+                JCVideoPlayer.releaseAllVideos()
+            }
+
+            override fun onPageSelected(position: Int) {
+            }
+        })
     }
 
     override fun loadVideoDetails(detailBean: List<VideoDetailBean>?) {

--- a/app/src/main/res/layout/item_detail_phvideo.xml
+++ b/app/src/main/res/layout/item_detail_phvideo.xml
@@ -4,7 +4,7 @@
                                              xmlns:tools="http://schemas.android.com/tools"
                                              android:orientation="vertical"
                                              android:layout_width="match_parent"
-                                             android:layout_height="match_parent">
+                                             android:layout_height="wrap_content">
 
 
     <TextView

--- a/config.gradle
+++ b/config.gradle
@@ -65,7 +65,7 @@ ext {
             "lottie"                : "com.airbnb.android:lottie:2.1.0",
             "progressbar"           : "me.zhanghai.android.materialprogressbar:library:1.4.1",
             "transitionhelper"      : "me.immortalz:transitionhelper:1.0.6",
-            "swipebacklayout"       : "cn.bingoogolapple:bga-swipebacklayout:1.1.0@aar",
+            "swipebacklayout"       : "cn.bingoogolapple:bga-swipebacklayout:1.2.0@aar",
             "gif-drawable"          : "pl.droidsonroids.gif:android-gif-drawable:1.2.8",
 
             //Event


### PR DESCRIPTION
1.修复新闻页面视频高度过高占满一页的bug
2.升级SwipeBack库，修复导致的Android9.0上不能全屏显示的bug
3.添加视频自动播放功能